### PR TITLE
Optimize CBOR map to Go struct decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@
 
 # Go workspace file
 go.work
+
+# pprof files
+*.pprof
+
+# examples (temporary)
+examples/

--- a/decoder.go
+++ b/decoder.go
@@ -553,7 +553,7 @@ func (dec *Decoder) readUint8() (uint64, error) {
 // readUint16 reads a 16-bit unsigned integer from the input stream.
 func (dec *Decoder) readUint16() (uint64, error) {
 	// Reuse dec.buffer if it's large enough.
-	if len(dec.buffer) < 2 {
+	if cap(dec.buffer) < 2 {
 		dec.buffer = make([]byte, 2)
 	}
 	buf := dec.buffer[:2]
@@ -569,7 +569,7 @@ func (dec *Decoder) readUint16() (uint64, error) {
 // readUint32 reads a 32-bit unsigned integer from the input stream.
 func (dec *Decoder) readUint32() (uint64, error) {
 	// Reuse dec.buffer if it's large enough.
-	if len(dec.buffer) < 4 {
+	if cap(dec.buffer) < 4 {
 		dec.buffer = make([]byte, 4)
 	}
 	buf := dec.buffer[:4]
@@ -585,7 +585,7 @@ func (dec *Decoder) readUint32() (uint64, error) {
 // readUint64 reads a 64-bit unsigned integer from the input stream.
 func (dec *Decoder) readUint64() (uint64, error) {
 	// Reuse dec.buffer if it's large enough.
-	if len(dec.buffer) < 8 {
+	if cap(dec.buffer) < 8 {
 		dec.buffer = make([]byte, 8)
 	}
 	buf := dec.buffer[:8]

--- a/decoder.go
+++ b/decoder.go
@@ -1017,7 +1017,7 @@ func (dec *Decoder) decodeMap(rv reflect.Value, ai byte) error {
 				return err
 			}
 
-			keyStr := fmt.Sprintf("%v", key)
+			keyStr := toString(key)
 
 			fv, ok := fieldCache[keyStr]
 			if !ok {
@@ -1969,6 +1969,50 @@ func (dec *Decoder) readMapKey() (any, error) {
 		return dec.readStringBytes(n)
 	default:
 		return nil, fmt.Errorf("cbor: invalid map key: %X", b)
+	}
+}
+
+// toString converts any Go value to a string as fast as possible
+// while avoiding allocations.
+func toString(v any) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case int:
+		return strconv.Itoa(v)
+	case int8:
+		return strconv.Itoa(int(v))
+	case int16:
+		return strconv.Itoa(int(v))
+	case int32:
+		return strconv.Itoa(int(v))
+	case int64:
+		return strconv.Itoa(int(v))
+	case uint:
+		return strconv.Itoa(int(v))
+	case uint8:
+		return strconv.Itoa(int(v))
+	case uint16:
+		return strconv.Itoa(int(v))
+	case uint32:
+		return strconv.Itoa(int(v))
+	case uint64:
+		return strconv.Itoa(int(v))
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%v", v)
 	}
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -819,6 +819,10 @@ func (dec *Decoder) decodeArray(rv reflect.Value, ai byte) error {
 	return nil
 }
 
+// fieldCache is a cache of reflect.Type fields indexed by name used
+// to speed up decoding CBOR maps into struct values.
+type fieldCache map[string]reflect.Value
+
 // decodeMap decodes a CBOR map into the given reflect.Value.
 //
 // ai is the additional information byte for the map, which contains the
@@ -1027,7 +1031,7 @@ func (dec *Decoder) decodeMap(rv reflect.Value, ai byte) error {
 		// To reduce allocations, we use a map[int]reflect.Value
 		// to cache the field index and value. This is used to
 		// avoid the need to call rv.FieldByName for each key.
-		fieldCache := make(map[string]reflect.Value, rv.NumField())
+		fieldCache := make(fieldCache, rv.NumField())
 
 		// We need both caches because we need to support both
 		// `cbor:"1,keyasint"` and `cbor:"name"` tags.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -877,16 +877,15 @@ func TestDecodeCWTClaims(t *testing.T) {
 // goarch: arm64
 // pkg: github.com/picatz/cbor
 // BenchmarkUnmarshalCWTClaims
-// BenchmarkUnmarshalCWTClaims-8   	  937486	      1272 ns/op	     864 B/op	      17 allocs/op
+// BenchmarkUnmarshalCWTClaims-8   	  810913	      1276 ns/op	     856 B/op	      16 allocs/op
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
-	b.StopTimer()
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
 	data, err := hex.DecodeString("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
 	if err != nil {
 		b.Fatal("hex.DecodeString:", err)
 	}
 
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var v claims
 		if err := cbor.Unmarshal(data, &v); err != nil {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -882,6 +882,24 @@ func TestDecodeCWTClaims(t *testing.T) {
 // BenchmarkUnmarshalCWTClaims-8   	  116292	     10138 ns/op	    2712 B/op	     165 allocs/op
 // PASS
 // ok  	github.com/picatz/cbor	1.367s
+//
+// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/picatz/cbor
+// BenchmarkUnmarshalCWTClaims
+// BenchmarkUnmarshalCWTClaims-8   	  697783	      1649 ns/op	     648 B/op	      46 allocs/op
+// PASS
+// ok  	github.com/picatz/cbor	1.314s
+//
+// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/picatz/cbor
+// BenchmarkUnmarshalCWTClaims
+// BenchmarkUnmarshalCWTClaims-8   	  692305	      1628 ns/op	     424 B/op	      39 allocs/op
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	b.StopTimer()
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -927,6 +927,28 @@ func TestDecodeCWTClaims(t *testing.T) {
 	}
 }
 
+// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalString$ github.com/picatz/cbor -v
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/picatz/cbor
+// BenchmarkUnmarshalString
+// BenchmarkUnmarshalString-8   	 5436266	       185.9 ns/op	     656 B/op	       5 allocs/op
+func BenchmarkUnmarshalString(b *testing.B) {
+	data, err := hex.DecodeString("6B68656C6C6F20776F726C64")
+	if err != nil {
+		b.Fatal("hex.DecodeString:", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v string
+		if err := cbor.Unmarshal(data, &v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
 //
 // goos: darwin
@@ -936,6 +958,8 @@ func TestDecodeCWTClaims(t *testing.T) {
 // BenchmarkUnmarshalCWTClaims-8   	  810913	      1276 ns/op	     856 B/op	      16 allocs/op
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+	//
+	// {1: "coap://as.example.com", 2: "erikw", 3: "coap://light.example.com", 4: 1444064944, 5: 1443944944, 6: 1443944944, 7: h'0B71'}
 	data, err := hex.DecodeString("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
 	if err != nil {
 		b.Fatal("hex.DecodeString:", err)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -115,6 +115,62 @@ func TestDecodeInt64(t *testing.T) {
 	}
 }
 
+func TestDecodeUInt(t *testing.T) {
+	data := "\x01"
+
+	var value uint
+	err := cbor.NewDecoder(bytes.NewBufferString(data)).Decode(&value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if value != 1 {
+		t.Fatal("expected 1, got", value)
+	}
+}
+
+func TestDecodeUIntPointer(t *testing.T) {
+	data := "\x01"
+
+	var value *uint
+	err := cbor.NewDecoder(bytes.NewBufferString(data)).Decode(&value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *value != 1 {
+		t.Fatal("expected 1, got", value)
+	}
+}
+
+func TestDecodeUInt32(t *testing.T) {
+	data := "\x01"
+
+	var value uint32
+	err := cbor.NewDecoder(bytes.NewBufferString(data)).Decode(&value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if value != 1 {
+		t.Fatal("expected 1, got", value)
+	}
+}
+
+func TestDecodeUInt32Pointer(t *testing.T) {
+	data := "\x01"
+
+	var value *uint32
+	err := cbor.NewDecoder(bytes.NewBufferString(data)).Decode(&value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *value != 1 {
+		t.Fatal("expected 1, got", value)
+	}
+}
+
 func TestDecodeInt64Pointer(t *testing.T) {
 	data := "\x01"
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -808,9 +808,7 @@ var benchDecodeMalformedValue []uint8
 // goarch: arm64
 // pkg: github.com/picatz/cbor
 // BenchmarkDecodeMalformed
-// BenchmarkDecodeMalformed-8   	12116209	        94.26 ns/op	     128 B/op	       5 allocs/op
-// PASS
-// ok  	github.com/picatz/cbor	1.417s
+// BenchmarkDecodeMalformed-8   	 4152103	       289.8 ns/op	     712 B/op	       7 allocs/op
 func BenchmarkDecodeMalformed(b *testing.B) {
 	// This is a malformed CBOR data stream.
 	data := []byte{0x9B, 0x00, 0x00, 0x42, 0xFA, 0x42, 0xFA, 0x42, 0xFA, 0x42} // designed to cause an error (large array)
@@ -879,35 +877,7 @@ func TestDecodeCWTClaims(t *testing.T) {
 // goarch: arm64
 // pkg: github.com/picatz/cbor
 // BenchmarkUnmarshalCWTClaims
-// BenchmarkUnmarshalCWTClaims-8   	  116292	     10138 ns/op	    2712 B/op	     165 allocs/op
-// PASS
-// ok  	github.com/picatz/cbor	1.367s
-//
-// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
-//
-// goos: darwin
-// goarch: arm64
-// pkg: github.com/picatz/cbor
-// BenchmarkUnmarshalCWTClaims
-// BenchmarkUnmarshalCWTClaims-8   	  697783	      1649 ns/op	     648 B/op	      46 allocs/op
-// PASS
-// ok  	github.com/picatz/cbor	1.314s
-//
-// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
-//
-// goos: darwin
-// goarch: arm64
-// pkg: github.com/picatz/cbor
-// BenchmarkUnmarshalCWTClaims
-// BenchmarkUnmarshalCWTClaims-8   	  692305	      1628 ns/op	     424 B/op	      39 allocs/op
-//
-// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
-//
-// goos: darwin
-// goarch: arm64
-// pkg: github.com/picatz/cbor
-// BenchmarkUnmarshalCWTClaims
-// BenchmarkUnmarshalCWTClaims-8   	  862381	      1383 ns/op	     424 B/op	      39 allocs/op
+// BenchmarkUnmarshalCWTClaims-8   	  937486	      1272 ns/op	     864 B/op	      17 allocs/op
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	b.StopTimer()
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
@@ -920,32 +890,6 @@ func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var v claims
 		if err := cbor.Unmarshal(data, &v); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-// $ go test -benchmem -run=^$ -bench ^BenchmarkDecodeCWTClaims$ github.com/picatz/cbor -v
-//
-// goos: darwin
-// goarch: arm64
-// pkg: github.com/picatz/cbor
-// BenchmarkDecodeCWTClaims
-// BenchmarkDecodeCWTClaims-8   	  116398	     10221 ns/op	    2712 B/op	     165 allocs/op
-// PASS
-// ok  	github.com/picatz/cbor	1.385s
-func BenchmarkDecodeCWTClaims(b *testing.B) {
-	b.StopTimer()
-	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
-	data, err := hex.DecodeString("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
-	if err != nil {
-		b.Fatal("hex.DecodeString:", err)
-	}
-
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		var v claims
-		if err := cbor.NewDecoder(bytes.NewReader(data)).Decode(&v); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -900,6 +900,14 @@ func TestDecodeCWTClaims(t *testing.T) {
 // pkg: github.com/picatz/cbor
 // BenchmarkUnmarshalCWTClaims
 // BenchmarkUnmarshalCWTClaims-8   	  692305	      1628 ns/op	     424 B/op	      39 allocs/op
+//
+// $ go test -benchmem -run=^$ -bench ^BenchmarkUnmarshalCWTClaims$ github.com/picatz/cbor -v
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/picatz/cbor
+// BenchmarkUnmarshalCWTClaims
+// BenchmarkUnmarshalCWTClaims-8   	  862381	      1383 ns/op	     424 B/op	      39 allocs/op
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	b.StopTimer()
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -12,6 +12,54 @@ import (
 )
 
 func ExampleDecoder() {
+	const data = "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64" // {"hello": "world"}
+
+	var value map[string]string
+	err := cbor.NewDecoder(bytes.NewBufferString(data)).Decode(&value)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output: world
+	fmt.Println(value["hello"])
+}
+
+func TestDecoderStructTag(t *testing.T) {
+	const data = "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64" // {"hello": "world"}
+
+	type example struct {
+		Hello string `cbor:"hello"`
+	}
+
+	var value example
+	err := cbor.NewDecoder(bytes.NewBufferString(data)).Decode(&value)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output: world
+	fmt.Println(value.Hello)
+}
+
+type testStructHello struct {
+	Hello string `cbor:"hello"`
+}
+
+func TestDecoderStruct_tag(t *testing.T) {
+	const cborStream = "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64" // {"hello": "world"}
+
+	var value testStructHello
+	err := cbor.NewDecoder(bytes.NewBufferString(cborStream)).Decode(&value)
+	if err != nil {
+		panic(err)
+	}
+
+	if value.Hello != "world" {
+		t.Fatal("expected world, got", value.Hello)
+	}
+}
+
+func TestDecoderMap(t *testing.T) {
 	const cborStream = "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64" // {"hello": "world"}
 
 	var value map[string]string
@@ -20,8 +68,9 @@ func ExampleDecoder() {
 		panic(err)
 	}
 
-	// Output: world
-	fmt.Println(value["hello"])
+	if value["hello"] != "world" {
+		t.Fatal("expected world, got", value["hello"])
+	}
 }
 
 func TestDecodeInt(t *testing.T) {


### PR DESCRIPTION
This PR aims to fix #1 by improving the CBOR map to Go struct decoding performance.



Metric | Before | After | Delta | Delta %
|:-- |:-- |:-- |:-- |:--
ns/op | 10138 | 1276 | -8862 | -87.50%
B/op | 2712 | 856 | -1856 | -68.20%
allocs/op | 165 | 16 | -149 | -90.30%



#### Before
<img width="1378" alt="Screenshot 2023-01-01 at 3 59 47 PM" src="https://user-images.githubusercontent.com/14850816/210184425-06d0958a-59f0-4cea-af0a-bbaf51adca9d.png">

#### After
<img width="1369" alt="Screenshot 2023-01-01 at 9 43 44 PM" src="https://user-images.githubusercontent.com/14850816/210191842-b1d65c5f-71a0-4f25-9999-42eda98641a8.png">