### PR TITLE
Build field cache once per Go struct type

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,74 @@
+package cbor
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// structTypeCache is a cache of struct types used to reduce allocations
+// when decoding CBOR into structs, avoiding the need to reflect on the
+// struct type for each field.
+var structTypeCache sync.Map
+
+// storeFieldCache adds a struct type to the cache from the given reflect.Value
+// if it is not already in the cache.
+func storeFieldCache(rv reflect.Value) fieldCache {
+	// Check if the type is already in the cache.
+	t := rv.Type()
+
+	if v, ok := structTypeCache.Load(t); ok {
+		fc, ok := v.(fieldCache)
+		if !ok {
+			panic("cbor: invalid field cache")
+		}
+		return fc
+	}
+
+	fieldCache := make(fieldCache, rv.NumField())
+
+	// Iterate over the map fields in the struct to build
+	// a cache of field names and keyasint values.
+	for i := 0; i < rv.NumField(); i++ {
+		field := rv.Type().Field(i)
+
+		// If the field is unexported, skip it.
+		if field.PkgPath != "" {
+			continue
+		}
+
+		// If the field has no cbor tag, add it to the
+		// field name cache with the field name as the key.
+		if field.Tag == "" {
+			fieldCache[field.Name] = rv.Field(i)
+			continue
+		}
+
+		// Check cbor tag for keyasint.
+		if tag := field.Tag.Get("cbor"); tag != "" {
+			// Use index to avoid allocating a new string.
+			if idx := strings.Index(tag, ",keyasint"); idx != -1 {
+				// If the tag is "keyasint", add it to the field cache.
+				fieldCache[tag[:idx]] = rv.Field(field.Index[0])
+			} else {
+				// If the tag is not "keyasint", add it to the field cache
+				// with the tag value as the key.
+				fieldCache[tag] = rv.Field(field.Index[0])
+			}
+		}
+	}
+
+	structTypeCache.Store(t, fieldCache)
+
+	return fieldCache
+}
+
+// loadFieldCache returns the field cache for the given struct type, or nil
+// if the type is not in the cache.
+func loadFieldCache(t reflect.Type) fieldCache {
+	if v, ok := structTypeCache.Load(t); ok {
+		return v.(fieldCache)
+	}
+
+	return nil
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -933,7 +933,7 @@ func TestDecodeCWTClaims(t *testing.T) {
 // goarch: arm64
 // pkg: github.com/picatz/cbor
 // BenchmarkUnmarshalString
-// BenchmarkUnmarshalString-8   	 5436266	       185.9 ns/op	     656 B/op	       5 allocs/op
+// BenchmarkUnmarshalString-8   	 7057992	       159.6 ns/op	     656 B/op	       5 allocs/op
 func BenchmarkUnmarshalString(b *testing.B) {
 	data, err := hex.DecodeString("6B68656C6C6F20776F726C64")
 	if err != nil {
@@ -955,7 +955,7 @@ func BenchmarkUnmarshalString(b *testing.B) {
 // goarch: arm64
 // pkg: github.com/picatz/cbor
 // BenchmarkUnmarshalCWTClaims
-// BenchmarkUnmarshalCWTClaims-8   	  810913	      1276 ns/op	     856 B/op	      16 allocs/op
+// BenchmarkUnmarshalCWTClaims-8   	 1915150	       541.9 ns/op	     773 B/op	       7 allocs/op
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
 	//


### PR DESCRIPTION
This PR follows up #3, but instead of building the struct field cache for each struct that is decoded, the cache is built once the first time the struct is seen by the decoder. Struct field caches are stored in a global [`sync.Map`](https://pkg.go.dev/sync#Map) used by all decoder instances. This generally reduces the number of allocations, and avoid spending time in [`reflect.StructTag.Get`](https://pkg.go.dev/reflect#StructTag.Get) which is somewhat expensive.

🌟 Overall, these changes lead to a ~50% performance improvement (`ns/op`, `allocs/op`).

#### Before
<img width="1734" alt="Screenshot 2023-01-02 at 12 22 06 PM" src="https://user-images.githubusercontent.com/14850816/210262599-e83bc587-cc24-4b4b-8c46-ee09419acc6c.png">

#### After
<img width="1734" alt="Screenshot 2023-01-02 at 12 22 25 PM" src="https://user-images.githubusercontent.com/14850816/210262621-9030f6b7-cb35-4711-b1e5-7e5d12a2cf2c.png">



Metric | Before | After | Delta | Delta %
:-- |:-- |:-- |:-- |:--
ns/op | 1276 | 541.9 | -734.1 | -57.70%
B/op | 856 | 773 | -83 | -9.71%
allocs/op | 16 | 7 | -9 | -56.25%

